### PR TITLE
count 추가 (현재 단순히 20 정적할당)

### DIFF
--- a/filemap.c
+++ b/filemap.c
@@ -2173,9 +2173,10 @@ find_page:
 
 			if (iocb->ki_flags & IOCB_NOWAIT)
 				goto would_block;
-			page_cache_sync_readahead(mapping,
-					ra, filp,
-					index, last_index - index);
+			/*page_cache_sync_readahead(mapping,
+			 *		ra, filp,
+			 *		index, last_index - index);
+			 */
 			page = find_get_page(mapping, index);
 			if (unlikely(page == NULL))
 				goto no_cached_page;

--- a/filemap.c
+++ b/filemap.c
@@ -1036,6 +1036,9 @@ static int wake_page_function(wait_queue_entry_t *wait, unsigned mode, int sync,
 	struct page * page;
 	wait_queue_head_t *q;
 
+	int error =0;
+	int count = 20;
+
 	if (wait_page->page != key->page)
 	       return 0;
 	key->page_match = 1;
@@ -1058,24 +1061,50 @@ static int wake_page_function(wait_queue_entry_t *wait, unsigned mode, int sync,
 	 * migrating the wait queue implementation
 	 */
 
-	if(wait_page->nr_to_read == 1)
-		return autoremove_wake_function(wait, mode, sync, key); 
-	
 	if(!mapping || !test_bit(PG_lru,&wait_page->page->flags))
 		return autoremove_wake_function(wait, mode, sync, key);
 	
 	while(1){
-		wait_page->nr_to_read--;
-		
-		page = find_get_page(mapping,++index);
+		if(wait_page->nr_to_read == 1 || count <=0)
+			return autoremove_wake_function(wait, mode, sync, key); 
+	
+		page = find_get_page(mapping,index+1);
 		if(!page){
-			return autoremove_wake_function(wait,mode,sync,key);
+			page = page_cache_alloc(mapping);
+			if(!page)
+				return autoremove_wake_function(wait, mode, sync, key);
+			error = add_to_page_cache_lru(page, mapping, index,
+				mapping_gfp_constraint(mapping, GFP_KERNEL));
+			if(error){
+				put_page(page);
+				if (error == -EEXIST) {
+					error = 0;
+					continue; //re-find this page
+				}
+				return autoremove_wake_function(wait, mode, sync, key);
+			}
+			ClearPageError(page);
+			error = mapping->a_ops->readpage(NULL, page);
+			if (unlikely(error)) {
+				if (error == AOP_TRUNCATED_PAGE) {
+					put_page(page);
+					error = 0;
+					continue;
+				}
+				put_page(page);
+				return autoremove_wake_function(wait, mode, sync, key);
+			}
+
 		}else if(PageReadahead(page) || wait_page->nr_to_read <= 0){
 			put_page(page);
 			return autoremove_wake_function(wait, mode, sync, key);
-		}else if(PageUptodate(page)){
+		}
+		if(PageUptodate(page)){
 			put_page(page);
-			continue;
+			index++;
+			wait_page->nr_to_read--;
+			count--;
+			continue;//find next page
 		}else{	
 			/* migrate othre wait queue */
 			q = page_waitqueue(compound_head(wait_page->page));

--- a/filemap.c
+++ b/filemap.c
@@ -1073,7 +1073,7 @@ static int wake_page_function(wait_queue_entry_t *wait, unsigned mode, int sync,
 			page = page_cache_alloc(mapping);
 			if(!page)
 				return autoremove_wake_function(wait, mode, sync, key);
-			error = add_to_page_cache_lru(page, mapping, index,
+			error = add_to_page_cache_lru(page, mapping, index+1,
 				mapping_gfp_constraint(mapping, GFP_KERNEL));
 			if(error){
 				put_page(page);
@@ -1095,7 +1095,7 @@ static int wake_page_function(wait_queue_entry_t *wait, unsigned mode, int sync,
 				return autoremove_wake_function(wait, mode, sync, key);
 			}
 
-		}else if(PageReadahead(page) || wait_page->nr_to_read <= 0){
+		}else if(PageReadahead(page) || wait_page->nr_to_read <= 1){
 			put_page(page);
 			return autoremove_wake_function(wait, mode, sync, key);
 		}


### PR DESCRIPTION
find_get_page 실패시 page 재할당 + read 구현

기존 while문 전에 nr_to_read ==1 비교 와
while문 안에서 nr_to_read--후에 nr_to_read <=0 비교
--> while문 처음 nr_to_read ==1 한번 비교

nr_to_read와 index의 변경은 PageUpToDate 에서만.
find를 다시 해야할 경우 변경없이 continue로 수행

readpage 함수 parameter인 filp를 NULL로 전달
(문제가 될 경우 nr_to_read와 함께 filp 전달해야함
하지만 현재 매핑된 readpage 함수 내부에서 filp 사용 안함)